### PR TITLE
Check if exports have been updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,23 @@ script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR/indra
   - python check_references.py
   - python export/relations_graph.py
+  # test if exports have been updated
+  # bel_resources must be installed to generate belns exports
+  # generate exports then take git diff and look only at lines that changed
+  # lines containing date, timestamp, or version should be ignored
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.5" ]]; then
+      pip install bel_resources;
       python export/obo.py;
+      python export/hgnc_ids.py;
+      python export/belns.py;
+      belns_diff=$(git diff -U0 export/famplex.belns | egrep "^[\+-][^\+-]");
+      belns=$(echo "$belns_diff" | egrep -v
+      "^[\+-](VersionString|CreatedDateTime)");
+      obo_diff=$(git diff -U0 export/famplex.obo | egrep "^[\+-][^\+-]");
+      obo=$(echo "$obo_diff" | egrep -v "^[\+-]date");
+      hgnc=$(git diff -U0 export/hgnc_symbol_map.csv | egrep "^[\+-][^\+-]");
+      if [[ ! -z $belns ]] || [[ ! -z $obo ]] || [[ ! -z $hgnc ]]; then
+        echo "FAIL exports have not been updated";
+        exit 1;
+      fi
     fi


### PR DESCRIPTION
This PR updates the travis build to check if exports have been updated. This is the correct branch that should be merged. Exports are generated. Then git diffs are computed on the export files. An option is used to make git diff return no context lines and the remaining lines are filtered with grep to ensure that only lines that have changed in the file are considered. grep is used to check that the files differ only in inessential lines (timestamps, dates, version numbers). This approach seems to look pretty well.