### PR TITLE
Use Python 3.6 only for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - "2.7"
-  - "3.5"
+  - "3.6"
 before_install:
   - sudo apt-get install graphviz
   - pwd


### PR DESCRIPTION
This PR changes the current Python 2.7/3.5 test environment to just 3.6.