### PR TITLE
Add ability to have optional entity descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ the FamPlex namespace.
 * ```entities.csv```. A registry of the families and complexes defined in the
   FamPlex namespace.
 
+* ```descriptions.csv```. Descriptions and citations of some entities. Contains
+  three columns: the FamPlex name, pipe separated reference CURIEs, and a 
+  textual description.
+
 * ```grounding_map.csv```. Explicit mapping of text strings to identifiers in
   biological databases.
 

--- a/descriptions.csv
+++ b/descriptions.csv
@@ -1,0 +1,1 @@
+CBF3,interpro:IPR016072,"SKP1 (together with SKP2) was identified as an essential component of the cyclin A-CDK2 S phase kinase complex"

--- a/export/famplex.obo
+++ b/export/famplex.obo
@@ -1608,6 +1608,7 @@ inverse_is_a: HGNC:CAV3
 [Term]
 id: FPLX:CBF3
 name: CBF3
+def: "SKP1 (together with SKP2) was identified as an essential component of the cyclin A-CDK2 S phase kinase complex" [interpro:IPR016072]
 synonym: "CBF3 complex" EXACT []
 synonym: "CBF3" EXACT []
 synonym: "kinetochore centromere binding factor 3" EXACT []

--- a/export/obo.py
+++ b/export/obo.py
@@ -14,7 +14,8 @@ Synonym = collections.namedtuple('Synonym', ['name', 'status'])
 
 
 class OboTerm(object):
-    def __init__(self, term_id, name, rels, synonyms=None, xrefs=None, description=None, provenance=None):
+    def __init__(self, term_id, name, rels, synonyms=None, xrefs=None,
+                 description=None, provenance=None):
         self.term_id = term_id
         self.name = name
         self.description = description

--- a/export/obo.py
+++ b/export/obo.py
@@ -14,10 +14,15 @@ Synonym = collections.namedtuple('Synonym', ['name', 'status'])
 
 
 class OboTerm(object):
-    def __init__(self, term_id, name, rels, synonyms=None, xrefs=None):
+    def __init__(self, term_id, name, rels, synonyms=None, xrefs=None, description=None, provenance=None):
         self.term_id = term_id
         self.name = name
+        self.description = description
         self.synonyms = synonyms
+        if provenance is None:
+            self.provenance = []
+        else:
+            self.provenance = provenance
         if xrefs is not None:
             self.xrefs = xrefs
         else:
@@ -28,6 +33,8 @@ class OboTerm(object):
         obo_str = '[Term]\n'
         obo_str += 'id: %s:%s\n' % (self.term_id.ns, self.term_id.id)
         obo_str += 'name: %s\n' % self.name
+        if self.description is not None:
+            obo_str += 'def: "%s" [%s]\n' % (self.description, ','.join(self.provenance))
         for synonym in self.synonyms:
             obo_str += 'synonym: "%s" %s []\n' % (synonym.name, synonym.status)
         for xref in self.xrefs:
@@ -55,11 +62,19 @@ def get_obo_terms():
     obo_terms = []
     path_this = os.path.dirname(os.path.abspath(__file__))
     entities_file = os.path.join(path_this, os.pardir, 'entities.csv')
+    descriptions_file = os.path.join(path_this, os.pardir, 'descriptions.csv')
     grounding_file = os.path.join(path_this, os.pardir, 'grounding_map.csv')
     equiv_file = os.path.join(path_this, os.pardir, 'equivalences.csv')
     rel_file = os.path.join(path_this, os.pardir, 'relations.csv')
     with open(entities_file, 'r') as fh:
         entities = [l.strip() for l in fh.readlines()]
+    with open(descriptions_file, 'r') as fh:
+        entity_decriptions = {}
+        csvreader = csv.reader(fh, delimiter=str(u','), lineterminator='\r\n',
+                               quoting=csv.QUOTE_MINIMAL,
+                               quotechar=str(u'"'))
+        for fplx_id, references, description in csvreader:
+            entity_decriptions[fplx_id] = (references.split('|'), description)
     with open(equiv_file, 'r') as fh:
         csvreader = csv.reader(fh, delimiter=str(u','), lineterminator='\r\n',
                                quoting=csv.QUOTE_MINIMAL,
@@ -122,7 +137,11 @@ def get_obo_terms():
         # If the entity has no isa relations, connect it to the root
         if not rels[entity]['is_a'] and not rels[entity]['part_of']:
             rels[entity]['is_a'].append(Reference('FPLX', 'root'))
-        term = OboTerm(entity_id, name, rels[entity], synonyms, xrefs)
+
+        provenance, description = \
+            entity_decriptions.get(entity_id.id, (None, None))
+        term = OboTerm(entity_id, name, rels[entity], synonyms, xrefs,
+                       description=description, provenance=provenance)
         obo_terms.append(term)
     obo_terms.append(OboTerm(Reference('FPLX', 'root'),
                              'PROTEIN-FAMILY-OR-COMPLEX',


### PR DESCRIPTION
This PR allows the curator to specify a description for a give entity. They can also add the reference(s) to where the description came from if they didn't write it themselves.

This PR also updates the OBO exporter to reflect the descriptions when available and makes a new export.

