### PR TITLE
Load grounding map fix

### DIFF
--- a/famplex/load.py
+++ b/famplex/load.py
@@ -51,7 +51,7 @@ def _construct_grounding_map(rows):
     for row in rows:
         text = row[0]
         db_refs = {'TEXT': text}
-        db_refs.update({ns: id_ for ns, id_ in zip(row[1::2], row[2::2])})
+        db_refs.update({ns: id_ for ns, id_ in zip(row[1::2], row[2::2]) if ns})
         gmap[text] = db_refs if len(db_refs) > 1 else None
     return gmap
 

--- a/famplex/tests/test_load.py
+++ b/famplex/tests/test_load.py
@@ -1,0 +1,8 @@
+from famplex.load import load_grounding_map
+
+
+def test_load_grounding_map():
+    gm = load_grounding_map()
+    for text, db_refs in gm.items():
+        assert db_refs['TEXT'] == text
+        assert '' not in db_refs


### PR DESCRIPTION
This PR fixes a bug in the function `famplex.load.load_grounding_map` that caused most of the db_refs dicts which formed the values of the returned dictionary to contain an unwanted entry with empty strings for both key and value