### PR TITLE
Add linting script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         export PYTHONPATH=$PYTHONPATH:$HOME/indra
         python check_references.py
+        python lint.py
         python export/relations_graph.py
         python export/obo.py
         python export/hgnc_ids.py

--- a/lint.py
+++ b/lint.py
@@ -1,0 +1,48 @@
+"""Scripts for ensuring a canonical ordering of the famplex resource files."""
+
+import csv
+import os
+
+from famplex.load import _load_csv
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RESOURCES_PATH = os.path.join(HERE, 'famplex', 'resources')
+
+
+def _write_csv(filename, rows):
+    with open(filename, 'w') as file:
+        writer = csv.writer(
+            file,
+            delimiter=str(u','),
+            lineterminator='\r\n',
+            quoting=csv.QUOTE_MINIMAL,
+            quotechar=str(u'"'),
+        )
+        writer.writerows(rows)
+
+
+def _lint_csv(path, has_header: bool = False):
+    rows = _load_csv(path)
+    if has_header:
+        first, *rest = rows
+        new_rows = [first, *sorted(rest)]
+    else:
+        new_rows = sorted(rows)
+    _write_csv(path, new_rows)
+
+
+def main():
+    for resource, has_header in [
+        ('entities.csv', False),
+        ('relations.csv', False),
+        ('equivalences.csv', False),
+        ('grounding_map.csv', False),
+        ('gene_prefixes.csv', True),
+        ('descriptions.csv', False),
+    ]:
+        path = os.path.join(HERE, resource)
+        _lint_csv(path, has_header=has_header)
+
+
+if __name__ == '__main__':
+    main()

--- a/lint.py
+++ b/lint.py
@@ -1,7 +1,8 @@
-"""Scripts for ensuring a canonical ordering of the famplex resource files."""
+"""A script for ensuring a canonical ordering of the famplex resource files."""
 
 import csv
 import os
+import sys
 
 from famplex.load import _load_csv
 
@@ -21,7 +22,8 @@ def _write_csv(filename, rows):
         writer.writerows(rows)
 
 
-def _lint_csv(path, has_header: bool = False):
+def _lint_csv(path, has_header: bool = False) -> bool:
+    """Lint a CSV document and return false if changes were made."""
     rows = _load_csv(path)
     if has_header:
         first, *rest = rows
@@ -29,9 +31,11 @@ def _lint_csv(path, has_header: bool = False):
     else:
         new_rows = sorted(rows)
     _write_csv(path, new_rows)
+    return new_rows == rows
 
 
 def main():
+    ret = True
     for resource, has_header in [
         ('entities.csv', False),
         ('relations.csv', False),
@@ -41,7 +45,11 @@ def main():
         ('descriptions.csv', False),
     ]:
         path = os.path.join(HERE, resource)
-        _lint_csv(path, has_header=has_header)
+        res = _lint_csv(path, has_header=has_header)
+        if not res:
+            print(f'Need to lint {path}')
+        ret = ret and res
+    sys.exit(0 if ret else 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This script will canonicalize the order of entries in the famplex files. This will make it easier to curate since you can put new entries anywhere, as well as hopefully making diffs a bit easier to manager.

It also adds checking for properly linted files into CI, to make sure nobody forgets to do it.

It should be run before update_resources.py (or perhaps combined together)